### PR TITLE
allow getBy to receive options

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,13 @@
     "leveldown": "^0.10.2"
   },
   "dependencies": {
-    "through": "~2.3.4",
-    "level-hooks": "~4.4.3",
-    "level-delete-range": "~0.1.0",
-    "level-sublevel": "^5.2.0",
-    "pairs": "0.0.2",
     "bytewise": "^0.7.0",
-    "lodash.defaults": "^2.4.1"
+    "level-delete-range": "~0.1.0",
+    "level-hooks": "~4.4.3",
+    "level-sublevel": "^5.2.0",
+    "lodash.defaults": "^2.4.1",
+    "pairs": "0.0.2",
+    "through": "~2.3.4",
+    "through2": "^0.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "level-delete-range": "~0.1.0",
     "level-sublevel": "^5.2.0",
     "pairs": "0.0.2",
-    "bytewise": "^0.7.0"
+    "bytewise": "^0.7.0",
+    "lodash.defaults": "^2.4.1"
   }
 }

--- a/test/subindex.js
+++ b/test/subindex.js
@@ -65,23 +65,10 @@ describe('level-index', function() {
 
     function doQuery(err) {
       if (err) return done(err);
-      var hits = 0;
       db.getBy('name', 'foo', {limit: 2}, function (err, data) {
         if (err) return done(err);
-        hits++;
-        switch (hits) {
-          case 1:
-            expect(data.key).to.equal(0);
-            expect(data.value.name).to.equal('foo');
-            expect(data.value.feature).to.equal('awesome');
-            break;
-          case 2:
-            expect(data.key).to.equal(1);
-            expect(data.value.name).to.equal('foo');
-            expect(data.value.feature).to.equal('shy');
-            done();
-            break;
-        }
+        expect(data.length).to.equal(2);
+        done();
       });
     }
   });


### PR DESCRIPTION
- one use of the options is to override the result limit so that getBy
  can return multiple hits.
- the options has been introduced in a backwards compatible manner.
- all tests should still be passing.