### PR TITLE
fix encode() for browserified version

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var bytewise = require('bytewise'),
 var defaults = require('lodash.defaults');
 
 function encode(key) {
-  return bytewise.encode(key).toString('hex');
+  return Buffer.prototype.toString.call(bytewise.encode(key), 'hex');
 }
 
 function decode(key) {


### PR DESCRIPTION
use Buffer's toString instead of Uint8Array's (which always returns [object Uint8Array])